### PR TITLE
Add option to clear cache staging dir

### DIFF
--- a/AutoREACTER.py
+++ b/AutoREACTER.py
@@ -141,8 +141,9 @@ def AutoREACTER(input_file: str) -> None:
 
     # Parse and validate user-provided input
     input_parser = InputParser()
-    cache_manager = GetCacheDir()
+    cache_manager = GetCacheDir(clear_staging=True)
     cache_dir = cache_manager.staging_dir
+
 
     # Create a dated directory for this specific run
     run_manager = RunDirectoryManager(cache_manager.cache_base_dir)

--- a/AutoREACTER/cache.py
+++ b/AutoREACTER/cache.py
@@ -44,6 +44,7 @@ class GetCacheDir:
         """
         self.staging_dir.mkdir(parents=True, exist_ok=True)
 
+        failed = []
         for item in self.staging_dir.iterdir():
             try:
                 if item.is_symlink() or item.is_file():
@@ -52,8 +53,12 @@ class GetCacheDir:
                     shutil.rmtree(item)
             except Exception as e:
                 print(f"[WARN] Failed to remove staging cache item {item}: {e}")
+                failed.append(item)
 
-        print(f"[OK] Cleared staging cache: {self.staging_dir}")
+        if failed:
+            print(f"[WARN] Staging cache partially cleared ({len(failed)} item(s) could not be removed): {self.staging_dir}")
+        else:
+            print(f"[OK] Cleared staging cache: {self.staging_dir}")
 
     def get_git_root(self) -> Path:
         """

--- a/AutoREACTER/cache.py
+++ b/AutoREACTER/cache.py
@@ -15,25 +15,52 @@ class GetCacheDir:
     structure with a staging area.
     """
 
-    def __init__(self):
-        """Initialize cache directory structure."""
+    def __init__(self, clear_staging: bool = False):
+        """
+        Initialize cache directory structure.
+
+        Args:
+            clear_staging:
+                If True, clear all contents inside cache/00_cache.
+                The 00_cache directory itself is preserved.
+        """
         self.git_root = self.get_git_root()
         self.cache_base_dir = self.git_root / "cache"
         self.cache_base_dir.mkdir(parents=True, exist_ok=True)
 
         # Staging directory for temporary files before moving to dated run folders
         self.staging_dir = self.cache_base_dir / "00_cache"
-        os.makedirs(self.staging_dir, exist_ok=True)
+        self.staging_dir.mkdir(parents=True, exist_ok=True)
+
+        if clear_staging:
+            self.clear_staging_dir()
+
+    def clear_staging_dir(self) -> None:
+        """
+        Clear all files and folders inside the staging cache directory.
+
+        This only clears cache/00_cache contents.
+        It does not delete dated run folders.
+        """
+        self.staging_dir.mkdir(parents=True, exist_ok=True)
+
+        for item in self.staging_dir.iterdir():
+            try:
+                if item.is_symlink() or item.is_file():
+                    item.unlink()
+                elif item.is_dir():
+                    shutil.rmtree(item)
+            except Exception as e:
+                print(f"[WARN] Failed to remove staging cache item {item}: {e}")
+
+        print(f"[OK] Cleared staging cache: {self.staging_dir}")
 
     def get_git_root(self) -> Path:
         """
         Return the root directory of the current git repository.
         
         Falls back to a path derived from this script's location if git
-        command fails (e.g., when running outside a git repository).
-        
-        Returns:
-            Path: Root directory path
+        command fails.
         """
         try:
             out = subprocess.check_output(
@@ -243,6 +270,8 @@ class RetentionCleanup:
                     and pattern.match(folder.name)
                 ):
                     shutil.rmtree(folder)
+                    print(f"[OK] Deleted: {folder}")
+            return
 
         try:
             days = int(mode)

--- a/docs/source/change_log.md
+++ b/docs/source/change_log.md
@@ -23,6 +23,12 @@ This serves two purposes:
     At release time, you can move the Unreleased section changes into a new release version section.
  -->
 ---
+## [0.2.1] - 2026-05-04
+
+### Fixed
+- Fixed issue where `cache/00_cache` was not cleared when initiating a new AutoREACTER run.
+- Improved cache handling to prevent bugs caused by deleting cache files in the middle of a run.
+- Added a warning message when the `--cleanup` command is used to delete all cached runs, to prevent accidental data loss.
 
 ## [0.2.0] - 2026-05-01
 

--- a/examples/example_1.ipynb
+++ b/examples/example_1.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "input_parser = InputParser()\n",
     "\n",
-    "cache_manager = GetCacheDir()\n",
+    "cache_manager = GetCacheDir(clear_staging=True)\n",
     "cache_dir = cache_manager.staging_dir\n",
     "\n",
     "run_manager = RunDirectoryManager(cache_manager.cache_base_dir)\n",


### PR DESCRIPTION
This PR addresses issue #65: `0.3v: Cache_00 won't clear when initiating the program`.

It also includes additional improvements to the package to prevent bugs caused by deleting cache files in the middle of a run.

This pull request introduces improvements to the cache management system in the `AutoREACTER` project, focusing on the ability to clear the staging cache directory before each run. The main changes add an option to clear the staging cache when initializing `GetCacheDir`, update usage in both the main script and example notebook, and enhance feedback during cache cleanup operations.

**Cache management improvements:**

* Added a `clear_staging` parameter to the `GetCacheDir` class initializer, allowing users to clear all contents from the `cache/00_cache` staging directory upon initialization. This is now used in both the main script (`AutoREACTER.py`) and the example notebook (`examples/example_1.ipynb`). [[1]](diffhunk://#diff-5d96933daf1293fc557466bf48e73f0e23fa21decba02e64ee53d029093346ceL18-R63) [[2]](diffhunk://#diff-2d71fbb0bd8137224403d5457890222c1c692e96260f64bf58465a668d56ea3bL144-R147) [[3]](diffhunk://#diff-e83092dd769c6711d95ae9251a11bcfe8c3a89dca7690baf254088f9d136f36cL39-R39)
* Implemented the `clear_staging_dir` method in `GetCacheDir` to remove all files and folders inside the staging cache directory, with warnings for any failures and a confirmation message upon completion.
* Updated the `run` method in `GetCacheDir` to print a confirmation message when deleting old run folders.