### PR TITLE
Rename 'replicas' to 'simulations' in codebase and documentation

### DIFF
--- a/AutoREACTER/input_parser.py
+++ b/AutoREACTER/input_parser.py
@@ -89,12 +89,18 @@ class MonomerEntry:
 @dataclass(slots=True)
 class Replica:
     """
-    Container for individual simulation replica/system definitions.
+    Structured representation of one simulation case.
+
+    This class was originally introduced when the input schema used the
+    top-level JSON key "replicas". The public input schema now uses
+    "simulations", but this internal class is still kept as Replica because it
+    represents one validated simulation condition/case used throughout the
+    workflow.
 
     Attributes:
-        tag: Unique identifier for the replica.
-        temperature: Replica temperature in Kelvin.
-        density: Replica density in g/cm^3.
+        tag: Unique identifier for the simulation case.
+        temperature: Target temperature in Kelvin.
+        density: Target density in g/cm^3.
         monomer_counts: Mapping of monomer names to counts in counts mode.
         monomer_ratios: Mapping of monomer names to ratios in ratio mode.
         total_atoms: Total target atom count, required for ratio mode.
@@ -130,7 +136,7 @@ class SimulationSetup:
         monomers: List of MonomerEntry objects representing the system composition.
         replicas: List of validated Replica objects.
         composition_method: Composition method, either "counts" or "ratio".
-        composition: Normalized composition dictionary from the input replicas.
+        composition: Normalized composition dictionary from the input simulations.
         ratio: Optional mapping of monomer IDs to ratios.
         number_of_total_atoms: Optional list of total atom targets.
         box_estimates: Optional estimated box size placeholder.
@@ -171,11 +177,11 @@ class InputParser:
         self.validate_basic_format(inputs)
 
         simulation_name = inputs["simulation_name"]
-        replicas_list = inputs["replicas"]
-        composition_method = self._get_inputs_mode(replicas_list)
+        simulations_list = inputs["simulations"]
+        composition_method = self._get_inputs_mode(simulations_list)
 
         validated_replicas = self._validate_replicas(
-            replicas_list,
+            simulations_list,
             composition_method,
         )
 
@@ -266,19 +272,19 @@ class InputParser:
                 f"Expected input to be a dictionary. Got {type(inputs).__name__} instead."
             )
 
-        required_keys = ["simulation_name", "replicas", "monomers"]
+        required_keys = ["simulation_name", "simulations", "monomers"]
         for key in required_keys:
             if key not in inputs:
                 raise InputSchemaError(
                     f"Missing required key: {key!r} in inputs dictionary."
                 )
 
-    def _get_inputs_mode(self, replicas_list: list) -> CompositionMethodType:
+    def _get_inputs_mode(self, simulations_list: list) -> CompositionMethodType:
         """
-        Determines the composition method from the replicas list.
+        Determines the composition method from the simulations list.
 
         Args:
-            replicas_list: The 'replicas' list from the input dictionary.
+            simulations_list: The 'simulations' list from the input dictionary.
 
         Returns:
             Composition method, either "counts" or "ratio".
@@ -287,14 +293,14 @@ class InputParser:
             InputSchemaError: If the list is invalid or mode cannot be inferred.
             InputConflictError: If a replica contains both counts and ratios.
         """
-        if not isinstance(replicas_list, list) or len(replicas_list) == 0:
+        if not isinstance(simulations_list, list) or len(simulations_list) == 0:
             raise InputSchemaError(
-                f"'replicas' must be a non-empty list. Got {type(replicas_list).__name__} instead."
+                f"'simulations' must be a non-empty list. Got {type(simulations_list).__name__} instead."
             )
 
         detected_modes: set[CompositionMethodType] = set()
 
-        for replica in replicas_list:
+        for replica in simulations_list:
             if not isinstance(replica, dict):
                 raise InputSchemaError(
                     f"Each replica must be a dictionary. Got {type(replica).__name__} instead."
@@ -320,7 +326,7 @@ class InputParser:
 
         if len(detected_modes) != 1:
             raise InputConflictError(
-                "All replicas must use the same composition method. Do not mix counts and ratio modes."
+                "All simulations must use the same composition method. Do not mix counts and ratio modes."
             )
 
         return detected_modes.pop()
@@ -422,7 +428,7 @@ class InputParser:
 
         Note:
             This method is kept for compatibility with older input schemas. The
-            current parser path validates composition through the 'replicas' section.
+            current parser path validates composition through the 'simulations' section.
 
         Args:
             composition_dict: Composition dictionary to validate.
@@ -484,7 +490,7 @@ class InputParser:
 
         Args:
             inputs: Raw input dictionary containing the top-level 'monomers' list.
-            systems: List of system dictionaries from the replicas section.
+            systems: List of system dictionaries from the simulations section.
             method: Composition method, either "counts" or "ratio".
 
         Raises:
@@ -533,7 +539,7 @@ class InputParser:
         Args:
             inputs: Raw input dictionary.
             method: Composition method, either "counts" or "ratio".
-            systems: Validated system dictionaries from the replicas section.
+            systems: Validated system dictionaries from the simulations section.
 
         Returns:
             A list of validated MonomerEntry objects.
@@ -794,7 +800,7 @@ class InputParser:
         method: CompositionMethodType,
     ) -> dict:
         """
-        Validates the 'replicas' section of the input.
+        Validates the 'simulations' section of the input.
 
         Args:
             systems: List of replica dictionaries.
@@ -805,7 +811,7 @@ class InputParser:
         """
         if not isinstance(systems, list) or not systems:
             raise InputSchemaError(
-                "'replicas' must be a non-empty list."
+                "'simulations' must be a non-empty list."
             )
 
         seen_tags: set[str] = set()
@@ -930,7 +936,7 @@ if __name__ == "__main__":
     # Example 1: Counts Mode
     inputs = {
         "simulation_name": "Example_Count_Mode",
-        "replicas": [
+        "simulations": [
             {
                 "tag": "10k",
                 "temperature": 300,
@@ -971,7 +977,7 @@ if __name__ == "__main__":
     # Example 2: Ratio Mode
     inputs_ratio = {
         "simulation_name": "Example_Ratio_Mode",
-        "replicas": [
+        "simulations": [
             {
                 "tag": "10k_base",
                 "temperature": 300,
@@ -1014,7 +1020,7 @@ if __name__ == "__main__":
     input_ff = {
         "simulation_name": "Example_Count_Mode_FF",
         "force_field": "PCFF",
-        "replicas": [
+        "simulations": [
             {
                 "tag": "10k",
                 "temperature": 300,

--- a/AutoREACTER/input_parser.py
+++ b/AutoREACTER/input_parser.py
@@ -272,6 +272,11 @@ class InputParser:
                 f"Expected input to be a dictionary. Got {type(inputs).__name__} instead."
             )
 
+        if "simulations" not in inputs and "replicas" in inputs:
+            raise InputSchemaError(
+                "Input key 'replicas' has been renamed to 'simulations'. Please update your input schema."
+            )
+
         required_keys = ["simulation_name", "simulations", "monomers"]
         for key in required_keys:
             if key not in inputs:
@@ -803,11 +808,11 @@ class InputParser:
         Validates the 'simulations' section of the input.
 
         Args:
-            systems: List of replica dictionaries.
+            systems: List of simulation dictionaries.
             method: Composition method, either "counts" or "ratio".
 
         Returns:
-            Normalized replicas dictionary.
+            Normalized simulations dictionary.
         """
         if not isinstance(systems, list) or not systems:
             raise InputSchemaError(

--- a/docs/source/input-configuration.md
+++ b/docs/source/input-configuration.md
@@ -24,7 +24,7 @@ Regardless of which mode you use, every `input.json` needs global settings and a
 
 ---
 
-### 2. Defining Replicas: Ratio Mode vs. Count Mode
+### 2. Defining Simulations: Ratio Mode vs. Count Mode
 
 When defining the `simulations` array, you have to decide how you want to calculate the number of molecules in the simulation box. 
 

--- a/docs/source/input-configuration.md
+++ b/docs/source/input-configuration.md
@@ -26,7 +26,7 @@ Regardless of which mode you use, every `input.json` needs global settings and a
 
 ### 2. Defining Replicas: Ratio Mode vs. Count Mode
 
-When defining the `replicas` array, you have to decide how you want to calculate the number of molecules in the simulation box. 
+When defining the `simulations` array, you have to decide how you want to calculate the number of molecules in the simulation box. 
 
 #### Option A: Ratio Mode (Target Atom Count)
 Use Ratio Mode when you know the total size of the simulation you want to run (e.g., ~10,000 atoms) and the ratio of your molecules, but you don't want to calculate the exact number of individual molecules by hand.
@@ -38,7 +38,7 @@ AutoREACTER will automatically calculate the correct number of molecules to hit 
 {
     "simulation_name": "Example_Ratio_Mode",
     "force_field": "PCFF",
-    "replicas": [
+    "simulations": [
         {
             "tag": "10k_base",
             "temperature": 300,
@@ -86,7 +86,7 @@ Use Count Mode when you know number of molecules instead of number of atoms. Ins
 {
     "simulation_name": "Example_Count_Mode",
     "force_field": "PCFF",
-    "replicas": [
+    "simulations": [
         {
             "tag": "10k",
             "temperature": 300,
@@ -127,12 +127,12 @@ Use Count Mode when you know number of molecules instead of number of atoms. Ins
 
 ### 3. Replica Parameters Breakdown
 
-For each object inside the `replicas` list, you must define:
+For each object inside the `simulations` list, you must define:
 
 * **`tag`**: A unique label for the replica (e.g., `"10k_base"`). This will be used to name the output subdirectories.
 * **`temperature`**: The system temperature in Kelvin. AutoREACTER uses this to configure the LAMMPS input scripts.
 * **`density`**: The initial target density of the simulation box (in g/cm³).
-* **Composition Setup:** Either provide `total_atoms` alongside `monomer_ratios` (Ratio Mode) **OR** provide `monomer_counts` (Count Mode). **Do not mix them in the same replica**.
+* **Composition Setup:** Either provide `total_atoms` alongside `monomer_ratios` (Ratio Mode) **OR** provide `monomer_counts` (Count Mode). **Do not mix them in the same simulation**.
 ---
 ### 4. Specifying the monomers or molecules.
 
@@ -157,7 +157,7 @@ Each monomer (or molecule) must include:
     ]
 ```
 
-**<u>IMPORTANT</u>**: The `monomers` section must remain consistent with the `monomer_counts` defined in each replica. All name tags must match exactly, and every monomer listed must have a corresponding count in each replica otherwise AutoREACTER will **raise an error** before proceeding with the chemistry. 
+**<u>IMPORTANT</u>**: The `monomers` section must remain consistent with the `monomer_counts` defined in each simulation. All name tags must match exactly, and every monomer listed must have a corresponding count in each simulation otherwise AutoREACTER will **raise an error** before proceeding with the chemistry. 
 
 **Note:** You can use [SMILES Generator / Checker](https://www.cheminfo.org/flavor/malaria/Utilities/SMILES_generator___checker/index.html) to generate valid SMILES strings. If SMILES strings are incorrect AutoREACTER will **raise an error** before proceeding.
 

--- a/examples/example_1_inputs_count_mode.json
+++ b/examples/example_1_inputs_count_mode.json
@@ -1,6 +1,6 @@
 {
     "simulation_name": "Example_Count_Mode",
-    "replicas": [
+    "simulations": [
         {
             "tag": "10k",
             "temperature": 300,

--- a/examples/example_1_inputs_count_mode_FF.json
+++ b/examples/example_1_inputs_count_mode_FF.json
@@ -1,7 +1,7 @@
 {
     "simulation_name": "Example_Count_Mode",
     "force_field": "PCFF",
-    "replicas": [
+    "simulations": [
         {
             "tag": "10k",
             "temperature": 300,

--- a/examples/example_1_inputs_ratio_mode.json
+++ b/examples/example_1_inputs_ratio_mode.json
@@ -1,6 +1,6 @@
 {
     "simulation_name": "Example_Ratio_Mode",
-    "replicas": [
+    "simulations": [
         {
             "tag": "10k_base",
             "temperature": 300,


### PR DESCRIPTION
This pull request updates the input schema for simulation definitions, replacing the top-level key `replicas` with `simulations` throughout the codebase, documentation, and example files. The changes ensure consistency between the user-facing input format and internal processing, and update all relevant error messages, docstrings, and code comments to match the new terminology.

**Input schema and codebase updates:**

* Replaced all occurrences of the `replicas` key with `simulations` in the input validation logic, error messages, and internal variable names in `AutoREACTER/input_parser.py`. This includes method arguments, docstrings, and error messages to reflect the new schema. [[1]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L92-R103) [[2]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L174-R184) [[3]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L269-R287) [[4]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L290-R303) [[5]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L323-R329) [[6]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L425-R431) [[7]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L487-R493) [[8]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L536-R542) [[9]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L797-R803) [[10]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L808-R814)

* Updated all example input JSON files to use the `simulations` key instead of `replicas`. [[1]](diffhunk://#diff-2152d1446ec842c6024e27e2d154d3a214ecadcc49366452db02de1787a1d1aeL3-R3) [[2]](diffhunk://#diff-3bf5f726b463d0295f338cbe12eb16d3f2155563be703bb9476924b2bcfddf10L4-R4) [[3]](diffhunk://#diff-8a1d5105274e29151a393d4d2d8963db6e1bb7959104a219539fcdfe2d3f7e19L3-R3)

**Documentation updates:**

* Modified the user documentation in `docs/source/input-configuration.md` to instruct users to define simulation cases under the `simulations` array, and updated all related explanations, examples, and terminology for clarity and consistency. [[1]](diffhunk://#diff-2300abd9e2a0d7e7706af85b38d1df5fe4a2feaa25480c359b5bdec7c6a0a3d0L29-R29) [[2]](diffhunk://#diff-2300abd9e2a0d7e7706af85b38d1df5fe4a2feaa25480c359b5bdec7c6a0a3d0L41-R41) [[3]](diffhunk://#diff-2300abd9e2a0d7e7706af85b38d1df5fe4a2feaa25480c359b5bdec7c6a0a3d0L89-R89) [[4]](diffhunk://#diff-2300abd9e2a0d7e7706af85b38d1df5fe4a2feaa25480c359b5bdec7c6a0a3d0L130-R135) [[5]](diffhunk://#diff-2300abd9e2a0d7e7706af85b38d1df5fe4a2feaa25480c359b5bdec7c6a0a3d0L160-R160)

**Backward compatibility and clarity:**

* Updated docstrings and comments to clarify that the internal `Replica` class still represents a single simulation case, even though the input schema now uses `simulations`. [[1]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L92-R103) [[2]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L133-R139)

* Revised test and example code to use the new schema, ensuring all validation and parsing logic expects `simulations` instead of `replicas`. [[1]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L933-R939) [[2]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L974-R980) [[3]](diffhunk://#diff-d1120a7e1d505c9d13a4b01b1f7ef71d0d69b1f924b895dc323e643e1f8ac482L1017-R1023)Switch the public input key from 'replicas' to 'simulations' across the codebase: InputParser now reads and validates inputs['simulations'], related helper names, error messages and docstrings were updated, and example JSON files and documentation were modified to match the new schema. The internal Replica class name and behavior are preserved for compatibility, with clarifying docstrings noting it models a single simulation case.